### PR TITLE
Рефакторинг MethodExecutor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.Coroutines
-
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -14,13 +13,8 @@ buildscript {
 }
 
 plugins {
-    kotlin("jvm") version "1.3.0" apply false
     java
-}
-
-
-allprojects {
-
+    kotlin("jvm") version "1.3.10"
 }
 
 tasks.withType(KotlinCompile::class.java).all {
@@ -31,6 +25,7 @@ tasks.withType(KotlinCompile::class.java).all {
 
 subprojects {
     version = "0.1"
+
     apply {
         plugin("org.jetbrains.kotlin.jvm")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,16 @@ import org.jetbrains.kotlin.gradle.dsl.Coroutines
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.10")
+    }
+}
+
 plugins {
     kotlin("jvm") version "1.3.0" apply false
     java

--- a/vk-api/build.gradle.kts
+++ b/vk-api/build.gradle.kts
@@ -6,14 +6,10 @@ group = "name.alatushkin.utils"
 
 plugins {
     java
-    id("com.jfrog.bintray") version "1.8.1"
-    `maven-publish`
     kotlin("jvm")
+    `maven-publish`
+    id("com.jfrog.bintray") version "1.8.1"
 }
-kotlin {
-
-}
-
 
 repositories {
     mavenLocal()
@@ -23,12 +19,11 @@ repositories {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.7")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.7")
-    implementation("com.fasterxml.jackson.core:jackson-core:2.9.7")
+    val jacksonVersion = "2.9.7"
+    implementation("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
     testImplementation("junit:junit:4.12")
-
-
 
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
@@ -43,13 +38,13 @@ val sourcesJar by tasks.creating(Jar::class) {
 }
 
 publishing {
-
     repositories {
         maven {
             // change to point to your repo, e.g. http://my.org/repo
             url = uri("$buildDir/repo")
         }
     }
+
     publications {
         create("mavenJava", MavenPublication::class.java) {
             from(components["java"])

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/MethodExecutor.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/MethodExecutor.kt
@@ -1,102 +1,24 @@
 package name.alatushkin.api.vk
 
-import name.alatushkin.api.vk.api.VkErrorException
-import name.alatushkin.api.vk.api.VkResponse
-import name.alatushkin.api.vk.generated.messages.Keyboard
+import name.alatushkin.api.vk.api.VkError
 import name.alatushkin.httpclient.HttpClient
-import name.alatushkin.httpclient.HttpMethod.POST
-import name.alatushkin.httpclient.RequestBody.FormUrlEncoded
 
 interface MethodExecutor {
-    suspend operator fun <T> invoke(method: VkMethod<T>): VkResponse<T>
-    val httpClient: HttpClient
-}
-
-interface MethodExecutorWithException {
-    @Throws(VkErrorException::class)
+    @Throws(VkError::class)
     suspend operator fun <T> invoke(method: VkMethod<T>): T
 
-    fun asMethodExecutor(): MethodExecutor
     val httpClient: HttpClient
+    val accessToken: String
 }
 
-fun MethodExecutor.withToken(accessToken: String): MethodExecutor {
-    return object : MethodExecutor {
-        override suspend fun <T> invoke(method: VkMethod<T>): VkResponse<T> {
-            method.presetProps["access_token"] = accessToken
-            return this@withToken(method)
-        }
-
-        override val httpClient: HttpClient
-            get() = this@withToken.httpClient
-    }
-}
-
-fun MethodExecutor.throwExceptionsOnError(): MethodExecutorWithException {
-    return object : MethodExecutorWithException {
-        override fun asMethodExecutor(): MethodExecutor {
-            return this@throwExceptionsOnError
-        }
-
-        override suspend fun <T> invoke(method: VkMethod<T>): T {
-            val result = this@throwExceptionsOnError(method)
-            if (result.error != null)
-                throw VkErrorException(result.error)
-
-            return result.response!!
-        }
-
-        override val httpClient: HttpClient
-            get() = this@throwExceptionsOnError.httpClient
-    }
-}
-
-class MethodExecutorImpl(
-    override val httpClient: HttpClient
+data class SimpleMethodExecutor(
+        override val httpClient: HttpClient,
+        override val accessToken: String
 ) : MethodExecutor {
 
-
-    override suspend fun <T> invoke(method: VkMethod<T>): VkResponse<T> {
-        val params = method.props
-            .filterValues { it != null }
-            .mapKeys { restorePropNames(it) }
-            .entries.map {
-            Pair(
-                caseConvert(it.key),
-                toStringRequestValue(it.value)
-            )
-        }.toMap() + method.presetProps + mapOf("v" to VERSION)
-
-        val httpRequest = POST(url = methodUrl(method), body = FormUrlEncoded(params))
-        val response = httpClient(httpRequest)
-        val vkResponse: VkResponse<T> = VK_OBJECT_MAPPER.readValue(response.data, method.classRef)
-        return vkResponse
-    }
-
-    private fun methodUrl(method: VkMethod<*>) = URL_PREFIX + method.apiMethodName
-
-    private fun restorePropNames(it: Map.Entry<String, Any?>): String {
-        return when (it.key) {
-            "cls" -> "class"
-            "obj" -> "object"
-            else -> it.key
-        }
-    }
-
-    private fun toStringRequestValue(it: Any?): String {
-        if (it is Array<*>)
-            return it.joinToString(",")
-        if (it is Keyboard)
-            return VK_OBJECT_MAPPER.writeValueAsString(it)
-        return it.toString()
-    }
-
-    companion object {
-        const val URL_PREFIX = "https://api.vk.com/method/"
-        const val VERSION = "5.87"
+    @Throws(VkError::class)
+    override suspend operator fun <T> invoke(method: VkMethod<T>): T {
+        method.presetProps["access_token"] = accessToken
+        return executeApiCall(httpClient, method).value()
     }
 }
-
-fun caseConvert(s: String) = CamelCaseToLowerUnderscore(s)
-fun CamelCaseToLowerUnderscore(s: String): String = s.replace("(.)(\\p{Upper})".toRegex(), "$1_$2").toLowerCase()
-

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/MethodExecutor.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/MethodExecutor.kt
@@ -1,0 +1,11 @@
+package name.alatushkin.api.vk
+
+import name.alatushkin.api.vk.api.VkError
+import name.alatushkin.httpclient.HttpClient
+
+interface MethodExecutor {
+    @Throws(VkError::class)
+    suspend operator fun <T> invoke(method: VkMethod<T>): T
+
+    val httpClient: HttpClient
+}

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/VkClient.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/VkClient.kt
@@ -3,13 +3,6 @@ package name.alatushkin.api.vk
 import name.alatushkin.api.vk.api.VkError
 import name.alatushkin.httpclient.HttpClient
 
-interface MethodExecutor {
-    @Throws(VkError::class)
-    suspend operator fun <T> invoke(method: VkMethod<T>): T
-
-    val httpClient: HttpClient
-}
-
 data class VkClient(val executor: MethodExecutor, val accessToken: String) {
 
     @Throws(VkError::class)

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/VkError.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/VkError.kt
@@ -2,13 +2,14 @@ package name.alatushkin.api.vk.api
 
 import com.fasterxml.jackson.annotation.JsonCreator
 
-data class VkError(val errorCode: Int, val errorMsg: String, var requestParams: Map<String, Any?>) {
+data class VkError(
+        val errorCode: Int,
+        val errorMsg: String,
+        var requestParams: Map<String, Any?>
+) : Exception(errorMsg) {
+
     @JsonCreator
     constructor(errorCode: Int, errorMsg: String, requestParams: Array<JsonKeyValueEntry>) : this(
-        errorCode, errorMsg, requestParams.map(
-            JsonKeyValueEntry::toPair
-        ).toMap()
+        errorCode, errorMsg, requestParams.map(JsonKeyValueEntry::toPair).toMap()
     )
 }
-
-class VkErrorException(val vkError: VkError) : RuntimeException(vkError.errorMsg)

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/VkResponse.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/VkResponse.kt
@@ -1,3 +1,7 @@
 package name.alatushkin.api.vk.api
 
-data class VkResponse<T>(val response: T?, val error: VkError?)
+data class VkResponse<T>(val response: T?, val error: VkError?) {
+
+    @Throws(VkError::class)
+    fun value(): T = response ?: throw error!!
+}

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/helperMethods.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/helperMethods.kt
@@ -1,6 +1,6 @@
 package name.alatushkin.api.vk.api
 
-import name.alatushkin.api.vk.MethodExecutor
+import name.alatushkin.api.vk.VkClient
 import name.alatushkin.api.vk.generated.audio.Audio
 import name.alatushkin.api.vk.generated.docs.Doc
 import name.alatushkin.api.vk.generated.market.MarketItem
@@ -42,7 +42,7 @@ fun Poll.fullId() = attachmentId("", id, ownerId)
 
 fun AudioMessage.fullId() = attachmentId("", id, ownerId)
 
-suspend fun MethodExecutor.sendTypings(groupId: Long, peerId: Long) {
+suspend fun VkClient.sendTypings(groupId: Long, peerId: Long) {
     this(
         MessagesSetActivityMethod(
             peerId = peerId,

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/utils/upload/uploadHelperMethods.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/utils/upload/uploadHelperMethods.kt
@@ -1,8 +1,8 @@
 package name.alatushkin.api.vk.api.utils.upload
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import name.alatushkin.api.vk.MethodExecutor
 import name.alatushkin.api.vk.VK_OBJECT_MAPPER
+import name.alatushkin.api.vk.VkClient
 import name.alatushkin.api.vk.api.VkError
 import name.alatushkin.api.vk.generated.docs.Doc
 import name.alatushkin.api.vk.generated.docs.GetMessagesUploadServerType
@@ -19,7 +19,7 @@ import java.nio.charset.Charset
 data class UploadPhotoResponse(val server: Long, val hash: String, val photo: String)
 
 @Throws(VkError::class)
-suspend fun MethodExecutor.uploadMessagePhoto(peerId: Long, byteArray: ByteArray): Photo {
+suspend fun VkClient.uploadMessagePhoto(peerId: Long, byteArray: ByteArray): Photo {
     val uploadUrl = this(PhotosGetMessagesUploadServerMethod(peerId)).uploadUrl
     val response = httpClient(
         HttpMethod.POST(
@@ -44,7 +44,7 @@ suspend fun MethodExecutor.uploadMessagePhoto(peerId: Long, byteArray: ByteArray
 data class UploadDocumentResponse(val file: String)
 
 @Throws(VkError::class)
-suspend fun MethodExecutor.uploadMessageDocument(
+suspend fun VkClient.uploadMessageDocument(
     peerId: Long,
     fileName: String,
     byteArray: ByteArray,

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/utils/upload/uploadHelperMethods.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/api/utils/upload/uploadHelperMethods.kt
@@ -2,9 +2,8 @@ package name.alatushkin.api.vk.api.utils.upload
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import name.alatushkin.api.vk.MethodExecutor
-import name.alatushkin.api.vk.MethodExecutorWithException
 import name.alatushkin.api.vk.VK_OBJECT_MAPPER
-import name.alatushkin.api.vk.api.VkErrorException
+import name.alatushkin.api.vk.api.VkError
 import name.alatushkin.api.vk.generated.docs.Doc
 import name.alatushkin.api.vk.generated.docs.GetMessagesUploadServerType
 import name.alatushkin.api.vk.generated.docs.methods.DocsGetMessagesUploadServerMethod
@@ -12,7 +11,6 @@ import name.alatushkin.api.vk.generated.docs.methods.DocsSaveMethod
 import name.alatushkin.api.vk.generated.photos.Photo
 import name.alatushkin.api.vk.generated.photos.methods.PhotosGetMessagesUploadServerMethod
 import name.alatushkin.api.vk.generated.photos.methods.PhotosSaveMessagesPhotoMethod
-import name.alatushkin.api.vk.throwExceptionsOnError
 import name.alatushkin.httpclient.FilePart
 import name.alatushkin.httpclient.HttpMethod
 import name.alatushkin.httpclient.RequestBody
@@ -20,13 +18,8 @@ import java.nio.charset.Charset
 
 data class UploadPhotoResponse(val server: Long, val hash: String, val photo: String)
 
-@Throws(VkErrorException::class)
+@Throws(VkError::class)
 suspend fun MethodExecutor.uploadMessagePhoto(peerId: Long, byteArray: ByteArray): Photo {
-    return this.throwExceptionsOnError().uploadMessagePhoto(peerId, byteArray)
-}
-
-@Throws(VkErrorException::class)
-suspend fun MethodExecutorWithException.uploadMessagePhoto(peerId: Long, byteArray: ByteArray): Photo {
     val uploadUrl = this(PhotosGetMessagesUploadServerMethod(peerId)).uploadUrl
     val response = httpClient(
         HttpMethod.POST(
@@ -36,26 +29,26 @@ suspend fun MethodExecutorWithException.uploadMessagePhoto(peerId: Long, byteArr
             )
         )
     )
-    val uploadPhototResponse: UploadPhotoResponse =
+    val uploadPhotoResponse: UploadPhotoResponse =
         VK_OBJECT_MAPPER.readValue(response.data.toString(Charset.forName("UTF-8")))
 
     return this(
         PhotosSaveMessagesPhotoMethod(
-            photo = uploadPhototResponse.photo,
-            hash = uploadPhototResponse.hash,
-            server = uploadPhototResponse.server
+            photo = uploadPhotoResponse.photo,
+            hash = uploadPhotoResponse.hash,
+            server = uploadPhotoResponse.server
         )
     ).first()
 }
 
 data class UploadDocumentResponse(val file: String)
 
-@Throws(VkErrorException::class)
-suspend fun MethodExecutorWithException.uploadMessageDocument(
+@Throws(VkError::class)
+suspend fun MethodExecutor.uploadMessageDocument(
     peerId: Long,
     fileName: String,
     byteArray: ByteArray,
-    vararg tags: String
+    tags: List<String> = emptyList()
 ): Doc {
     val uploadUrl = this(DocsGetMessagesUploadServerMethod(GetMessagesUploadServerType.DOC, peerId)).uploadUrl
 
@@ -77,9 +70,4 @@ suspend fun MethodExecutorWithException.uploadMessageDocument(
             tags = tags.joinToString(",")
         )
     ).first()
-}
-
-@Throws(VkErrorException::class)
-suspend fun MethodExecutor.uploadMessageDocument(peerId: Long, fileName: String, byteArray: ByteArray): Doc {
-    return this.throwExceptionsOnError().uploadMessageDocument(peerId, fileName, byteArray)
 }

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/executeApiCall.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/executeApiCall.kt
@@ -1,0 +1,44 @@
+package name.alatushkin.api.vk
+
+import name.alatushkin.api.vk.api.VkResponse
+import name.alatushkin.api.vk.generated.messages.Keyboard
+import name.alatushkin.httpclient.HttpClient
+import name.alatushkin.httpclient.HttpMethod
+import name.alatushkin.httpclient.RequestBody
+
+suspend fun <T> executeApiCall(httpClient: HttpClient, method: VkMethod<T>): VkResponse<T> {
+    val params = method.props
+            .filterValuesNotNull()
+            .mapKeys { caseConvert(restorePropNames(it.key)) }
+            .mapValues { toStringRequestValue(it.value) }
+            .plus(method.presetProps + mapOf("v" to VERSION))
+
+    val httpRequest = HttpMethod.POST(url = methodUrl(method), body = RequestBody.FormUrlEncoded(params))
+    val response = httpClient(httpRequest)
+    return VK_OBJECT_MAPPER.readValue(response.data, method.classRef)
+}
+
+private const val URL_PREFIX = "https://api.vk.com/method/"
+private const val VERSION = "5.87"
+
+private fun <K, V> Map<K, V?>.filterValuesNotNull(): Map<K, V> =
+        mapNotNull { (key, value) -> value?.let { key to value } }.toMap()
+
+private fun toStringRequestValue(it: Any): String = when (it) {
+    is Array<*> -> it.joinToString(",")
+    is Keyboard -> VK_OBJECT_MAPPER.writeValueAsString(it)
+    else -> it.toString()
+}
+
+private fun restorePropNames(key: String): String = when (key) {
+    "cls" -> "class"
+    "obj" -> "object"
+    else -> key
+}
+
+private fun methodUrl(method: VkMethod<*>) = URL_PREFIX + method.apiMethodName
+
+private fun caseConvert(s: String) = camelCaseToLowerUnderscore(s)
+
+private fun camelCaseToLowerUnderscore(s: String): String =
+        s.replace(Regex("(.)(\\p{Upper})"), "$1_$2").toLowerCase()

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/longpoll/SimpleServerLongPollEventSource.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/longpoll/SimpleServerLongPollEventSource.kt
@@ -2,12 +2,13 @@ package name.alatushkin.api.vk.longpoll
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.yield
-import name.alatushkin.api.vk.MethodExecutor
 import name.alatushkin.api.vk.SimpleMethodExecutor
 import name.alatushkin.api.vk.VK_OBJECT_MAPPER
+import name.alatushkin.api.vk.VkClient
 import name.alatushkin.api.vk.callback.CallbackEvent
 import name.alatushkin.api.vk.generated.groups.LongPollServer
 import name.alatushkin.api.vk.generated.groups.methods.GroupsGetLongPollServerMethod
+import name.alatushkin.api.vk.withToken
 import name.alatushkin.httpclient.HttpClient
 import name.alatushkin.httpclient.HttpMethod
 import org.slf4j.LoggerFactory
@@ -20,7 +21,7 @@ class SimpleServerLongPollEventSource(
     val httpClient: HttpClient,
     val timeOut: Int
 ) {
-    private val api: MethodExecutor = SimpleMethodExecutor(httpClient, vkToken)
+    private val api: VkClient = SimpleMethodExecutor(httpClient).withToken(vkToken)
 
     suspend fun getEvents(iterator: LongPollServer? = null): Pair<LongPollServer, List<CallbackEvent<*>>> {
 

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/longpoll/SimpleServerLongPollEventSource.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/longpoll/SimpleServerLongPollEventSource.kt
@@ -2,13 +2,12 @@ package name.alatushkin.api.vk.longpoll
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.yield
-import name.alatushkin.api.vk.MethodExecutorImpl
+import name.alatushkin.api.vk.MethodExecutor
+import name.alatushkin.api.vk.SimpleMethodExecutor
 import name.alatushkin.api.vk.VK_OBJECT_MAPPER
 import name.alatushkin.api.vk.callback.CallbackEvent
 import name.alatushkin.api.vk.generated.groups.LongPollServer
 import name.alatushkin.api.vk.generated.groups.methods.GroupsGetLongPollServerMethod
-import name.alatushkin.api.vk.throwExceptionsOnError
-import name.alatushkin.api.vk.withToken
 import name.alatushkin.httpclient.HttpClient
 import name.alatushkin.httpclient.HttpMethod
 import org.slf4j.LoggerFactory
@@ -21,7 +20,7 @@ class SimpleServerLongPollEventSource(
     val httpClient: HttpClient,
     val timeOut: Int
 ) {
-    private val api = MethodExecutorImpl(httpClient).withToken(vkToken).throwExceptionsOnError()
+    private val api: MethodExecutor = SimpleMethodExecutor(httpClient, vkToken)
 
     suspend fun getEvents(iterator: LongPollServer? = null): Pair<LongPollServer, List<CallbackEvent<*>>> {
 
@@ -47,14 +46,14 @@ class SimpleServerLongPollEventSource(
                     return lpServer.copy(argTs = lpResponse.ts) to emptyList()
                 }
                 2 -> {
-                    val newServ = getLongPollServer()
-                    log.debug("Vk say failed:2. Old ts:{} new ts: {}", lpServer.ts, newServ.ts)
-                    return newServ to emptyList()
+                    val newServer = getLongPollServer()
+                    log.debug("Vk say failed:2. Old ts:{} new ts: {}", lpServer.ts, newServer.ts)
+                    return newServer to emptyList()
                 }
                 3 -> {
-                    val newServ = getLongPollServer()
-                    log.debug("Vk say failed:3. Old ts:{} new ts: {}", lpServer.ts, newServ.ts)
-                    return newServ to emptyList()
+                    val newServer = getLongPollServer()
+                    log.debug("Vk say failed:3. Old ts:{} new ts: {}", lpServer.ts, newServer.ts)
+                    return newServer to emptyList()
                 }
             }
 
@@ -74,7 +73,7 @@ class SimpleServerLongPollEventSource(
 
 
     companion object {
-        val log = LoggerFactory.getLogger(SimpleUserLongPollEventSource::class.java)
+        val log = LoggerFactory.getLogger(SimpleUserLongPollEventSource::class.java)!!
     }
 }
 

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/longpoll/SimpleUserLongPollEventSource.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/longpoll/SimpleUserLongPollEventSource.kt
@@ -2,11 +2,12 @@ package name.alatushkin.api.vk.longpoll
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.yield
-import name.alatushkin.api.vk.MethodExecutor
 import name.alatushkin.api.vk.SimpleMethodExecutor
 import name.alatushkin.api.vk.VK_OBJECT_MAPPER
+import name.alatushkin.api.vk.VkClient
 import name.alatushkin.api.vk.generated.messages.LongpollParams
 import name.alatushkin.api.vk.generated.messages.methods.MessagesGetLongPollServerMethod
+import name.alatushkin.api.vk.withToken
 import name.alatushkin.httpclient.HttpClient
 import name.alatushkin.httpclient.HttpMethod
 import org.slf4j.LoggerFactory
@@ -19,7 +20,7 @@ class SimpleUserLongPollEventSource(
     val httpClient: HttpClient,
     val timeOut: Int
 ) {
-    private val api: MethodExecutor = SimpleMethodExecutor(httpClient, vkToken)
+    private val api: VkClient = SimpleMethodExecutor(httpClient).withToken(vkToken)
 
     suspend fun getEvents(iterator: LongpollParams? = null): Pair<LongpollParams, List<LongPollEvent>> {
 

--- a/vk-api/src/main/kotlin/name/alatushkin/api/vk/longpoll/SimpleUserLongPollEventSource.kt
+++ b/vk-api/src/main/kotlin/name/alatushkin/api/vk/longpoll/SimpleUserLongPollEventSource.kt
@@ -2,12 +2,11 @@ package name.alatushkin.api.vk.longpoll
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.yield
-import name.alatushkin.api.vk.MethodExecutorImpl
+import name.alatushkin.api.vk.MethodExecutor
+import name.alatushkin.api.vk.SimpleMethodExecutor
 import name.alatushkin.api.vk.VK_OBJECT_MAPPER
 import name.alatushkin.api.vk.generated.messages.LongpollParams
 import name.alatushkin.api.vk.generated.messages.methods.MessagesGetLongPollServerMethod
-import name.alatushkin.api.vk.throwExceptionsOnError
-import name.alatushkin.api.vk.withToken
 import name.alatushkin.httpclient.HttpClient
 import name.alatushkin.httpclient.HttpMethod
 import org.slf4j.LoggerFactory
@@ -20,7 +19,7 @@ class SimpleUserLongPollEventSource(
     val httpClient: HttpClient,
     val timeOut: Int
 ) {
-    private val api = MethodExecutorImpl(httpClient).withToken(vkToken).throwExceptionsOnError()
+    private val api: MethodExecutor = SimpleMethodExecutor(httpClient, vkToken)
 
     suspend fun getEvents(iterator: LongpollParams? = null): Pair<LongpollParams, List<LongPollEvent>> {
 
@@ -71,9 +70,8 @@ class SimpleUserLongPollEventSource(
         return api(MessagesGetLongPollServerMethod(groupId = groupId, needPts = true, lpVersion = 3L))
     }
 
-
     companion object {
-        val log = LoggerFactory.getLogger(SimpleUserLongPollEventSource::class.java)
+        val log = LoggerFactory.getLogger(SimpleUserLongPollEventSource::class.java)!!
     }
 }
 
@@ -82,7 +80,6 @@ private fun LongpollParams.copy(
     argServer: String? = null,
     argTs: Long? = null,
     argPts: Long? = null
-
 ): LongpollParams {
     return LongpollParams(
         key = argKey ?: key,

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/MethodExecutorImplTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/MethodExecutorImplTest.kt
@@ -5,17 +5,11 @@ import name.alatushkin.api.vk.generated.groups.methods.GroupsGetByIdMethod
 import name.alatushkin.httpclient.httpClient
 import org.junit.Test
 
-
 class MethodExecutorImplTest {
     @Test
-    fun smokeTest1() {
-
-        runBlocking {
-            val executor = MethodExecutorImpl(httpClient()).withToken(groupAccessToken)
-            val result = executor(GroupsGetByIdMethod().setGroupId(groupId))
-            println(result)
-
-        }
+    fun smokeTest1() = runBlocking {
+        val executor = SimpleMethodExecutor(httpClient(), groupAccessToken)
+        val result = executor(GroupsGetByIdMethod().setGroupId(groupId))
+        println(result)
     }
-
 }

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/SimpleMethodExecutorTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/SimpleMethodExecutorTest.kt
@@ -5,10 +5,10 @@ import name.alatushkin.api.vk.generated.groups.methods.GroupsGetByIdMethod
 import name.alatushkin.httpclient.httpClient
 import org.junit.Test
 
-class MethodExecutorImplTest {
+class SimpleMethodExecutorTest {
     @Test
     fun smokeTest1() = runBlocking {
-        val executor = SimpleMethodExecutor(httpClient(), groupAccessToken)
+        val executor = SimpleMethodExecutor(httpClient()).withToken(groupAccessToken)
         val result = executor(GroupsGetByIdMethod().setGroupId(groupId))
         println(result)
     }

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/api/utils/upload/HelperMethodsKtTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/api/utils/upload/HelperMethodsKtTest.kt
@@ -1,10 +1,11 @@
 package name.alatushkin.api.vk.api.utils.upload
 
 import kotlinx.coroutines.runBlocking
-import name.alatushkin.api.vk.MethodExecutor
 import name.alatushkin.api.vk.SimpleMethodExecutor
+import name.alatushkin.api.vk.VkClient
 import name.alatushkin.api.vk.api.toAttachmentId
 import name.alatushkin.api.vk.groupAccessToken
+import name.alatushkin.api.vk.withToken
 import name.alatushkin.httpclient.httpClient
 import org.junit.Test
 
@@ -14,7 +15,7 @@ class HelperMethodsKtTest {
         runBlocking {
             val timeOut = 95
             val httpClient = httpClient(readTimeout = timeOut * 1000)
-            val api: MethodExecutor = SimpleMethodExecutor(httpClient, groupAccessToken)
+            val api: VkClient = SimpleMethodExecutor(httpClient).withToken(groupAccessToken)
 
             val result = api
                 .uploadMessagePhoto(
@@ -31,7 +32,7 @@ class HelperMethodsKtTest {
         runBlocking {
             val timeOut = 95
             val httpClient = httpClient(readTimeout = timeOut * 1000)
-            val api: MethodExecutor = SimpleMethodExecutor(httpClient, groupAccessToken)
+            val api: VkClient = SimpleMethodExecutor(httpClient).withToken(groupAccessToken)
 
             val result = api
                 .uploadMessageDocument(

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/api/utils/upload/HelperMethodsKtTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/api/utils/upload/HelperMethodsKtTest.kt
@@ -1,10 +1,10 @@
 package name.alatushkin.api.vk.api.utils.upload
 
 import kotlinx.coroutines.runBlocking
-import name.alatushkin.api.vk.MethodExecutorImpl
+import name.alatushkin.api.vk.MethodExecutor
+import name.alatushkin.api.vk.SimpleMethodExecutor
 import name.alatushkin.api.vk.api.toAttachmentId
 import name.alatushkin.api.vk.groupAccessToken
-import name.alatushkin.api.vk.withToken
 import name.alatushkin.httpclient.httpClient
 import org.junit.Test
 
@@ -14,7 +14,7 @@ class HelperMethodsKtTest {
         runBlocking {
             val timeOut = 95
             val httpClient = httpClient(readTimeout = timeOut * 1000)
-            val api = MethodExecutorImpl(httpClient).withToken(groupAccessToken)
+            val api: MethodExecutor = SimpleMethodExecutor(httpClient, groupAccessToken)
 
             val result = api
                 .uploadMessagePhoto(
@@ -31,7 +31,7 @@ class HelperMethodsKtTest {
         runBlocking {
             val timeOut = 95
             val httpClient = httpClient(readTimeout = timeOut * 1000)
-            val api = MethodExecutorImpl(httpClient).withToken(groupAccessToken)
+            val api: MethodExecutor = SimpleMethodExecutor(httpClient, groupAccessToken)
 
             val result = api
                 .uploadMessageDocument(

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/generated/messages/methods/MessagesSendMethodTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/generated/messages/methods/MessagesSendMethodTest.kt
@@ -10,7 +10,7 @@ class MessagesSendMethodTest {
     fun smoke1() = runBlocking {
         val timeOut = 95
         val httpClient = httpClient(readTimeout = timeOut * 1000)
-        val api = MethodExecutorImpl(httpClient).withToken(groupAccessToken).throwExceptionsOnError()
+        val api: MethodExecutor = SimpleMethodExecutor(httpClient, groupAccessToken)
 
         val result = api(
             MessagesSendMethod(

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/generated/messages/methods/MessagesSendMethodTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/generated/messages/methods/MessagesSendMethodTest.kt
@@ -10,7 +10,7 @@ class MessagesSendMethodTest {
     fun smoke1() = runBlocking {
         val timeOut = 95
         val httpClient = httpClient(readTimeout = timeOut * 1000)
-        val api: MethodExecutor = SimpleMethodExecutor(httpClient, groupAccessToken)
+        val api: VkClient = SimpleMethodExecutor(httpClient).withToken(groupAccessToken)
 
         val result = api(
             MessagesSendMethod(

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/generated/wall/methods/WallGetMethodExtendedTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/generated/wall/methods/WallGetMethodExtendedTest.kt
@@ -1,9 +1,9 @@
 package name.alatushkin.api.vk.generated.wall.methods
 
 import kotlinx.coroutines.runBlocking
-import name.alatushkin.api.vk.MethodExecutorImpl
+import name.alatushkin.api.vk.MethodExecutor
+import name.alatushkin.api.vk.SimpleMethodExecutor
 import name.alatushkin.api.vk.userAccessToken
-import name.alatushkin.api.vk.withToken
 import name.alatushkin.httpclient.httpClient
 import org.junit.Test
 
@@ -12,30 +12,29 @@ class WallGetMethodExtendedTest {
     fun smoke1() = runBlocking {
         val timeOut = 95
         val httpClient = httpClient(readTimeout = timeOut * 1000)
-        val api = MethodExecutorImpl(httpClient).withToken(userAccessToken)
+        val api: MethodExecutor = SimpleMethodExecutor(httpClient, userAccessToken)
 
         val result = api(
             WallGetMethod(
                 domain = "departureMsk"
             )
         )
-        println(result.response)
-
+        println(result)
+        Unit
     }
 
     @Test
     fun smoke2() = runBlocking {
         val timeOut = 95
         val httpClient = httpClient(readTimeout = timeOut * 1000)
-        val api = MethodExecutorImpl(httpClient).withToken(userAccessToken)
+        val api: MethodExecutor = SimpleMethodExecutor(httpClient, userAccessToken)
 
         val result = api(
             WallGetMethodExtended(
                 domain = "departureMsk"
             )
         )
-        println(result.response)
-
+        println(result)
+        Unit
     }
-
 }

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/generated/wall/methods/WallGetMethodExtendedTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/generated/wall/methods/WallGetMethodExtendedTest.kt
@@ -1,9 +1,10 @@
 package name.alatushkin.api.vk.generated.wall.methods
 
 import kotlinx.coroutines.runBlocking
-import name.alatushkin.api.vk.MethodExecutor
 import name.alatushkin.api.vk.SimpleMethodExecutor
-import name.alatushkin.api.vk.userAccessToken
+import name.alatushkin.api.vk.VkClient
+import name.alatushkin.api.vk.groupAccessToken
+import name.alatushkin.api.vk.withToken
 import name.alatushkin.httpclient.httpClient
 import org.junit.Test
 
@@ -12,7 +13,7 @@ class WallGetMethodExtendedTest {
     fun smoke1() = runBlocking {
         val timeOut = 95
         val httpClient = httpClient(readTimeout = timeOut * 1000)
-        val api: MethodExecutor = SimpleMethodExecutor(httpClient, userAccessToken)
+        val api: VkClient = SimpleMethodExecutor(httpClient).withToken(groupAccessToken)
 
         val result = api(
             WallGetMethod(
@@ -27,7 +28,7 @@ class WallGetMethodExtendedTest {
     fun smoke2() = runBlocking {
         val timeOut = 95
         val httpClient = httpClient(readTimeout = timeOut * 1000)
-        val api: MethodExecutor = SimpleMethodExecutor(httpClient, userAccessToken)
+        val api: VkClient = SimpleMethodExecutor(httpClient).withToken(groupAccessToken)
 
         val result = api(
             WallGetMethodExtended(

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/longpoll/SimpleServerLongPollEventSourceTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/longpoll/SimpleServerLongPollEventSourceTest.kt
@@ -18,11 +18,13 @@ class SimpleServerLongPollEventSourceTest {
         runBlocking {
             val timeOut = 95
             val httpClient = httpClient(readTimeout = timeOut * 1000)
-            val api = MethodExecutorImpl(httpClient).withToken(groupAccessToken).throwExceptionsOnError()
+            val api: MethodExecutor = SimpleMethodExecutor(httpClient, groupAccessToken)
             val source = SimpleServerLongPollEventSource(groupAccessToken, groupId.toLong(), httpClient, timeOut)
+
             while (true) {
                 val (next, events) = source.getEvents()
                 yield()
+
                 if (events.isNotEmpty()) {
                     println(next.dump())
                     println(events)

--- a/vk-api/src/test/kotlin/name/alatushkin/api/vk/longpoll/SimpleServerLongPollEventSourceTest.kt
+++ b/vk-api/src/test/kotlin/name/alatushkin/api/vk/longpoll/SimpleServerLongPollEventSourceTest.kt
@@ -18,7 +18,7 @@ class SimpleServerLongPollEventSourceTest {
         runBlocking {
             val timeOut = 95
             val httpClient = httpClient(readTimeout = timeOut * 1000)
-            val api: MethodExecutor = SimpleMethodExecutor(httpClient, groupAccessToken)
+            val api: VkClient = SimpleMethodExecutor(httpClient).withToken(groupAccessToken)
             val source = SimpleServerLongPollEventSource(groupAccessToken, groupId.toLong(), httpClient, timeOut)
 
             while (true) {


### PR DESCRIPTION
1. `MethodExecutor` теперь бросает исключения
2. `MethodExecutor` теперь всегда добавляет к запросу `accessToken`
3. `MethodExecutor` больше не провоцирует создание множества уровней
вложенности
4. Основная работа `MethodExecutorImpl` перенесена в `executeApiCall()`
5. Бросается напрямую `VkError`

Со старым `MethodExecutor` было тяжело и вообще непонятно как работать. Он мог иногда бросать исключение, а иногда возвращать код ошибки. Непонятно было, прикрепит он токен или нет. На практике, при работе с `MethodExecutor`, мы всегда хотим, чтобы он бросал исключения (так как он в любом случае бросает исключения сериализации и исключения от `HttpClient`), и мы всегда хотим, чтобы он прикреплял токен (основной сервер ВК запросы без токена, вроде, не принимает).

Кроме того, такой интерфейс `MethodExecutor` готовит почву для добавления нормального `BatchMethodExecutor` с поддержкой ограничения частоты и с поддержкой метода execute (по 25 команд за раз).

P.S. Код, использующий (но не создающий) MethodExecutor, вроде, не сломается.